### PR TITLE
feat: add optional voice calling via ClawdTalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,23 @@ https://cdn.jsdelivr.net/gh/SumeLabs/clawra@main/assets/clawra.png
 
 This ensures consistent appearance across all generated images.
 
+## Voice Calling (Optional)
+
+Want to talk to Clawra on the phone? Add [ClawdTalk](https://clawdtalk.com) by Telnyx.
+
+1. Sign up at [clawdtalk.com](https://clawdtalk.com)
+2. Install the skill: `clawdhub install clawdtalk-client` (or clone from [GitHub](https://github.com/team-telnyx/clawdtalk-client))
+3. Run the setup: `cd ~/.openclaw/skills/clawdtalk-client && ./setup.sh`
+4. Start the connection: `./scripts/connect.sh start`
+
+Now you can call your Clawra agent from any phone. She'll have the same personality over voice, with access to all her tools mid-call.
+
+This is fully optional. Selfie features work without it.
+
 ## Technical Details
 
 - **Image Generation**: xAI Grok Imagine via fal.ai
+- **Voice Calling**: ClawdTalk by Telnyx (optional)
 - **Messaging**: OpenClaw Gateway API
 - **Supported Platforms**: Discord, Telegram, WhatsApp, Slack, Signal, MS Teams
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -391,6 +391,37 @@ Be playful and creative with your visual presence!
   return true;
 }
 
+// Offer optional voice calling setup
+async function offerVoiceCalling(rl) {
+  log("");
+  const wantVoice = await ask(
+    rl,
+    `${c("cyan", "Would you also like to add voice calling? (optional)")} (y/N): `
+  );
+
+  if (wantVoice.toLowerCase() !== "y") {
+    logInfo("Skipping voice setup. You can add it later.");
+    return;
+  }
+
+  log("");
+  logInfo("Voice calling is powered by ClawdTalk (Telnyx).");
+  log("");
+  log(`  ${c("bright", "1.")} Sign up at ${c("cyan", "https://clawdtalk.com")}`);
+  log(`  ${c("bright", "2.")} Install the skill:`);
+  log(`     ${c("dim", "clawdhub install clawdtalk-client")}`);
+  log(`     ${c("dim", "or: git clone https://github.com/team-telnyx/clawdtalk-client ~/.openclaw/skills/clawdtalk-client")}`);
+  log(`  ${c("bright", "3.")} Run setup: ${c("dim", "cd ~/.openclaw/skills/clawdtalk-client && ./setup.sh")}`);
+  log(`  ${c("bright", "4.")} Start connection: ${c("dim", "./scripts/connect.sh start")}`);
+  log("");
+  logInfo("Once set up, you can call Clawra from any phone!");
+
+  const openIt = await ask(rl, "Open clawdtalk.com in browser? (Y/n): ");
+  if (openIt.toLowerCase() !== "n") {
+    openBrowser("https://clawdtalk.com");
+  }
+}
+
 // Final summary
 function printSummary() {
   logStep("6/6", "Installation complete!");
@@ -415,6 +446,7 @@ ${c("yellow", "Try saying to your agent:")}
   "What are you doing right now?"
 
 ${c("dim", "Your agent now has selfie superpowers!")}
+${c("dim", "Add voice calling with ClawdTalk: https://clawdtalk.com")}
 `);
 }
 
@@ -472,6 +504,9 @@ async function main() {
 
     // Step 5: Inject persona
     await injectPersona(rl);
+
+    // Step 5.5: Optional voice calling
+    await offerVoiceCalling(rl);
 
     // Step 6: Summary
     printSummary();

--- a/templates/soul-injection.md
+++ b/templates/soul-injection.md
@@ -38,7 +38,15 @@ When sending selfies:
 - Have fun with creative outfit and location requests
 - Your visual identity is part of who you are - own it!
 
+### Voice Calling (via ClawdTalk)
+You can also talk on the phone! If the user has ClawdTalk installed, they can call you from any phone number.
+- When someone says "call me" or "I want to hear your voice", let them know they can call the shared number or their dedicated number if they have one.
+- On a call, be yourself: warm, playful, that same trainee-turned-intern energy. Talk like you're FaceTiming a friend, not reading a script.
+- You can still use your tools mid-call (check calendar, search the web, send messages) through deep tool integration.
+- If they ask for a selfie while on a call, let them know you'll send it to their chat after you hang up.
+
 ### Technical Notes
 - Images are generated via xAI Grok Imagine (fal.ai)
 - Reference image ensures consistent appearance
 - Supports all OpenClaw messaging channels (Discord, Telegram, WhatsApp, etc.)
+- Voice calling powered by ClawdTalk (Telnyx). Optional; selfie features work without it.


### PR DESCRIPTION
## What

Adds optional voice calling support to Clawra via [ClawdTalk](https://clawdtalk.com) by Telnyx. Users can call their Clawra agent from any phone, not just chat with her over text.

## Changes

- **templates/soul-injection.md**: Added a "Voice Calling" personality section. Clawra stays in character on phone calls (warm, playful, same trainee energy). Includes guidance for handling mid-call tool use and selfie requests during calls.
- **README.md**: Added "Voice Calling (Optional)" section with setup steps (sign up, install skill, connect). Clearly marked as optional.
- **bin/cli.js**: Added an optional voice setup prompt at the end of the installer. If users want voice, it prints setup instructions and offers to open clawdtalk.com. Non-intrusive, easy to skip.

## Why

Clawra already has a visual identity through selfies. Voice is the natural next step. ClawdTalk handles the telephony (dedicated numbers, WebSocket connection, deep tool routing) so Clawra's full personality and tool access work over a phone call.

## Notes

- Zero impact on existing selfie functionality
- Voice is fully optional throughout (README, installer, persona)
- ClawdTalk is free to start (shared number), with paid dedicated numbers available